### PR TITLE
hide consumed message by env parameter

### DIFF
--- a/kafka-consumer-java/src/main/java/Config.java
+++ b/kafka-consumer-java/src/main/java/Config.java
@@ -44,6 +44,7 @@ class Config {
     public static String STATSD_ROOT;
     public static String STATSD_HOST;
     public static boolean USE_PROMETHEUS;
+    public static boolean HIDE_CONSUMED_MESSAGE;
 
     public static void init() throws Exception {
         Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();

--- a/kafka-consumer-java/src/main/java/Monitor.java
+++ b/kafka-consumer-java/src/main/java/Monitor.java
@@ -87,7 +87,7 @@ public class Monitor {
                 "extra",
                 new JSONObject()
                     .put("message", new JSONObject().put("key", consumerRecord.key()))
-                    .put("value", (!Config.HIDE_CONSUMED_MESSAGE)? Record.value() : "Hidden")
+                    .put("value", (!Config.HIDE_CONSUMED_MESSAGE)? consumerRecord.value() : "Hidden")
             );
 
         write(log);
@@ -163,7 +163,7 @@ public class Monitor {
                 "extra",
                 new JSONObject()
                     .put("message", new JSONObject().put("key", consumerRecord.key()))
-                    .put("value", (!Config.HIDE_CONSUMED_MESSAGE)? Record.value() : "Hidden")
+                    .put("value", (!Config.HIDE_CONSUMED_MESSAGE)? consumerRecord.value() : "Hidden")
             )
             .put("err", new JSONObject().put("message", exception.getMessage()));
 
@@ -182,8 +182,8 @@ public class Monitor {
 
         var extra = new JSONObject()
             .put("message", new JSONObject()
-            .put("key", consumerRecord.key())
-            .put("value", (!Config.HIDE_CONSUMED_MESSAGE)? Record.value() : "Hidden")
+                .put("key", consumerRecord.key())
+                .put("value", (!Config.HIDE_CONSUMED_MESSAGE)? consumerRecord.value() : "Hidden"))
             .put("attempt", attempt);
 
         if (responseBody.isPresent()) {


### PR DESCRIPTION
Adds the env parameter HIDE_CONSUMED_MESSAGE to hide the consumed message rom monitor